### PR TITLE
Revert "comment out code that is removing label tags"

### DIFF
--- a/at2oac.xsl
+++ b/at2oac.xsl
@@ -99,13 +99,6 @@
 
 <!-- copy overloaded container labels to sibling physdesc -->
 <!-- TODO: specifically target AT @label values? -->
-<!-- 
-  I'm not sure why this code was added but it removes any label tags from container elements
-  This is not helpful because by default ArchiveSpace adds barcode information that is
-  needed to locate items in the label element.  For now just leave the label tag
-  alone and let display decide how best to show it. EV 4/5/2023
--->
-<!--
 <xsl:template match="ead:container[@label]">
   <xsl:element name="{name()}" namespace="{$namespace}">
     <xsl:apply-templates select="@*[name()!='label'] | node() "/>
@@ -116,7 +109,6 @@
     </xsl:element>
   </xsl:if>
 </xsl:template>
--->
 
 <!-- dao from AT style to MOAC style -->
 


### PR DESCRIPTION
This reverts commit 5f25018de43a95aae957264590ec682b06a28988.

One institution reported a problem with changes to container label tag display.